### PR TITLE
extract the authentication process to a separated middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/i-core/oauth2w
 
 go 1.12
+
+require github.com/kylelemons/godebug v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=

--- a/oauth2w.go
+++ b/oauth2w.go
@@ -15,13 +15,15 @@ import (
 	"net/http"
 )
 
+type ctxkey string
+
 const (
 	errMsgInternalServerError = "internal server error"
 	errMsgPermissionDenied    = "permission denied"
 
 	claimEmail = "email"
 
-	ctxkeyUser = "github.com/i-core/oauth2w/user"
+	ctxkeyUser ctxkey = "github.com/i-core/oauth2w/user"
 )
 
 // User contains data of an authenticated user.


### PR DESCRIPTION
This feature is needed to provide access to the data of an authenticated user inside HTTP handlers.