### PR TITLE
feat: add the data of an authorized user to the request context

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ go get github.com/i-core/oauth2w
 3. The middleware requests user roles using the interface `oauth2w.RoleFinder`.
 4. The middleware validates that the user has the required roles, and according to it, allows or not the HTTP request.
 
-**Notes**. Getting user roles is out of scope the library. You must provide an implementation of `oauth2w.RoleFinder`
+**Note 1**. Getting user roles is out of scope the library. You must provide an implementation of `oauth2w.RoleFinder`
 that receives user claims and returns the user's roles.
+
+**Note 2**. The middleware add the default role "\_default" to each authenticated user. You can use it in order to transparently add an access to endpoints that each authenticated user must have an access for.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,35 @@ func main() {
 }
 ```
 
+### Accessing user data
+
+```go
+package main
+
+import (
+    "fmt"
+    "net/http"
+    "os"
+
+    "github.com/i-core/oauth2w"
+)
+
+const oidcEndpoint = "https://openid-connect-provider.org"
+
+func main() {
+    authw, err := oauth2w.New(oidcEndpoint, &RoleFinder{})
+    if err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
+    http.HandleFunc("/profile", authw(func(w http.ResponseWriter, r *http.Request) {
+        user := oauth2w.FindUser(r.Context())
+        fmt.Printf("User %v\n", user)
+    }))
+    fmt.Println(http.ListenAndServe(":8080", nil))
+}
+```
+
 ### Usage with Ory Hydra and Werther
 
 When you use OpenID Connect Provider [ORY Hydra][hydra] with Identity Provider [Werther][werther] you can use
@@ -167,19 +196,14 @@ The code in this project is licensed under [MIT license][license].
 
 [doc-img]: https://godoc.org/github.com/i-core/oauth2w?status.svg
 [doc]: https://godoc.org/github.com/i-core/oauth2w
-
 [build-img]: https://travis-ci.com/i-core/oauth2w.svg?branch=master
 [build]: https://travis-ci.com/i-core/oauth2w
-
 [codecov-img]: https://codecov.io/gh/i-core/oauth2w/branch/master/graph/badge.svg
 [codecov]: https://codecov.io/gh/i-core/oauth2w
-
 [goreport-img]: https://goreportcard.com/badge/github.com/i-core/oauth2w
 [goreport]: https://goreportcard.com/report/github.com/i-core/oauth2w
-
 [contrib]: https://github.com/i-core/.github/blob/master/CONTRIBUTING.md
 [license]: LICENSE
-
 [oidc-spec-core]: https://openid.net/specs/openid-connect-core-1_0.html
 [hydra]: https://github.com/ory/hydra
 [werther]: https://github.com/i-core/werther

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/i-core/oauth2w
 
 go 1.12
+
+require github.com/kylelemons/godebug v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=

--- a/oauth2w.go
+++ b/oauth2w.go
@@ -21,7 +21,8 @@ const (
 	errMsgInternalServerError = "internal server error"
 	errMsgPermissionDenied    = "permission denied"
 
-	claimEmail = "email"
+	claimEmail  = "email"
+	defaultRole = "_default"
 
 	ctxkeyUser ctxkey = "github.com/i-core/oauth2w/user"
 )
@@ -200,6 +201,7 @@ func New(endpoint string, roleFinder RoleFinder, opts ...Option) (func([]string)
 					logDebug("Authorization failed while finding roles", "claims", claims, "rolesClaim", err)
 					return
 				}
+				roles = append(roles, defaultRole)
 
 				var found bool
 				for _, wr := range wantRoles {

--- a/oauth2w_test.go
+++ b/oauth2w_test.go
@@ -188,7 +188,16 @@ func TestMiddleware(t *testing.T) {
 			oidcStatus: http.StatusOK,
 			oidcBody:   toJSON(map[string]interface{}{"email": "test@example.org", "roles": []interface{}{"user"}}),
 			wantStatus: http.StatusOK,
-			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user"}},
+			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user", "_default"}},
+		},
+		{
+			name:       "authorized with the default role",
+			roles:      []string{"_default"},
+			token:      "foo",
+			oidcStatus: http.StatusOK,
+			oidcBody:   toJSON(map[string]interface{}{"email": "test@example.org", "roles": []interface{}{"user"}}),
+			wantStatus: http.StatusOK,
+			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user", "_default"}},
 		},
 		{
 			name:       "with log",
@@ -207,7 +216,7 @@ func TestMiddleware(t *testing.T) {
 			oidcStatus: http.StatusOK,
 			oidcBody:   toJSON(map[string]interface{}{"email": "test@example.org", "roles": []interface{}{"user"}}),
 			wantStatus: http.StatusOK,
-			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user"}},
+			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user", "_default"}},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
This is needed to provide the data of an authorized user to an underlying handler.