### PR TITLE
feat: add the default role to each authorized user

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ go get github.com/i-core/oauth2w
 3. The middleware requests user roles using the interface `oauth2w.RoleFinder`.
 4. The middleware validates that the user has the required roles, and according to it, allows or not the HTTP request.
 
-**Notes**. Getting user roles is out of scope the library. You must provide an implementation of `oauth2w.RoleFinder`
+**Note 1**. Getting user roles is out of scope the library. You must provide an implementation of `oauth2w.RoleFinder`
 that receives user claims and returns the user's roles.
+
+**Note 2**. The middleware add the default role "\_default" to each authenticated user. You can use it in order to transparently add an access to endpoints that each authenticated user must have an access for.
 
 ## Usage
 

--- a/oauth2w.go
+++ b/oauth2w.go
@@ -21,7 +21,8 @@ const (
 	errMsgInternalServerError = "internal server error"
 	errMsgPermissionDenied    = "permission denied"
 
-	claimEmail = "email"
+	claimEmail  = "email"
+	defaultRole = "_default"
 
 	ctxkeyUser ctxkey = "github.com/i-core/oauth2w/user"
 )
@@ -200,6 +201,7 @@ func New(endpoint string, roleFinder RoleFinder, opts ...Option) (func([]string)
 					logDebug("Authorization failed while finding roles", "claims", claims, "rolesClaim", err)
 					return
 				}
+				roles = append(roles, defaultRole)
 
 				var found bool
 				for _, wr := range wantRoles {

--- a/oauth2w_test.go
+++ b/oauth2w_test.go
@@ -188,7 +188,16 @@ func TestMiddleware(t *testing.T) {
 			oidcStatus: http.StatusOK,
 			oidcBody:   toJSON(map[string]interface{}{"email": "test@example.org", "roles": []interface{}{"user"}}),
 			wantStatus: http.StatusOK,
-			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user"}},
+			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user", "_default"}},
+		},
+		{
+			name:       "authorized with the default role",
+			roles:      []string{"_default"},
+			token:      "foo",
+			oidcStatus: http.StatusOK,
+			oidcBody:   toJSON(map[string]interface{}{"email": "test@example.org", "roles": []interface{}{"user"}}),
+			wantStatus: http.StatusOK,
+			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user", "_default"}},
 		},
 		{
 			name:       "with log",
@@ -207,7 +216,7 @@ func TestMiddleware(t *testing.T) {
 			oidcStatus: http.StatusOK,
 			oidcBody:   toJSON(map[string]interface{}{"email": "test@example.org", "roles": []interface{}{"user"}}),
 			wantStatus: http.StatusOK,
-			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user"}},
+			wantUser:   &oauth2w.User{Email: "test@example.org", Roles: []string{"user", "_default"}},
 		},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
Add the default role to each authorized user. This is needed in order to transparently add an access to endpoints that each authenticated user must have an access for.